### PR TITLE
Update to new archive layout and enhancements

### DIFF
--- a/src/main/kotlin/dev/crmodders/versionsgen/command/FileCommand.kt
+++ b/src/main/kotlin/dev/crmodders/versionsgen/command/FileCommand.kt
@@ -1,46 +1,127 @@
 package dev.crmodders.versionsgen.command
 
+import com.github.ajalt.clikt.completion.CompletionCandidates
 import com.github.ajalt.clikt.core.CliktCommand
-import com.github.ajalt.clikt.parameters.options.default
-import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.options.*
 import com.github.ajalt.clikt.parameters.types.long
+import dev.crmodders.versionsgen.utils.ArchiveCopyHandler
 import dev.crmodders.versionsgen.utils.HashUtils
 import dev.crmodders.versionsgen.utils.TimeUtils
-import java.nio.file.Files
-import kotlin.io.path.Path
+import java.net.URI
+import java.nio.file.Path
+import kotlin.io.path.fileSize
+import kotlin.system.exitProcess
 
 class FileCommand : CliktCommand(
+    help = "Copy archives in place and print JSON entry",
+    epilog = """
+        Specified archives are automatically placed in the correct location. The
+        archive folder is `./versions/[type]/[number]/[client|server]/`, so an
+        example would be `./versions/pre-alpha/0.3.1/client/`. Archive files
+        retain their original name. For the tool to properly place the archives,
+        try running or even placing the executable at the root of the archive
+        structure.
+        
+        URL archive locations may occasionally fail and most likely due to
+        antivirus software. Try running a second time and see if the connection
+        would go through.
+        
+        The JSON entry generated will only contain the specified JAR side and it
+        won't infer from already existing files. Specifying client will only
+        show the client data, server-only for server, and both when client and
+        server locations are specified. Though technically fine, it is not
+        possible to print the entry JSON without specifying any archives.
+    """.trimIndent(),
     name = "file",
-    help = "Generate a JSON object for a single file",
+    printHelpOnEmptyArgs = true,
 ) {
     companion object {
-        const val DEFAULT_URL = "https://raw.githubusercontent.com/CRModders/CosmicArchive/main/versions/pre-alpha/"
+        const val DEFAULT_BASE_URL = "https://raw.githubusercontent.com/CRModders/CosmicArchive/main/"
     }
 
-    private val path by option("--path", help = "Path to the Cosmic Reach jar")
-    private val type by option("--type", help = "Version type").default("pre_alpha")
-    private val releaseTime by option("--releaseTime", help = "Unix timestamp").long().default(TimeUtils.getTodayUnixTime())
-    private val url by option("--url", help = "Download url").default(DEFAULT_URL)
+    private val versionType by option(
+        "-t", "--type", "--version-type",
+        help = "Required: version type",
+        completionCandidates = CompletionCandidates.Fixed("pre-alpha"),
+    ).required()
+
+    private val versionNumber by option(
+        "-v", "--version", "--version-number",
+        help = "Required: version number",
+    ).required()
+
+    private val client by option(
+        "-c", "--client",
+        help = "Client JAR path or URL",
+        completionCandidates = CompletionCandidates.Path,
+    )
+
+    private val server by option(
+        "-s", "--server",
+        help = "Server JAR path or URL",
+        completionCandidates = CompletionCandidates.Path,
+    )
+
+    private val baseUrl by option(
+        "--url", "--base-url",
+        help = "Download url",
+    ).default(DEFAULT_BASE_URL)
+
+    private val releaseTime by option(
+        "--release-time",
+        help = "Unix timestamp",
+    ).long().default(TimeUtils.getTodayUnixTime())
+
+    private val stacktrace by option("--stacktrace", help = "Stacktrace on failure").flag()
 
     override fun run() {
-        val path = Path(path!!)
-        val fileName = path.fileName.toString()
+        if (client == null && server == null) {
+            System.err.println("Neither client nor server JAR was specified")
+            System.err.println("It is required to specify either --client, --server, or both")
+            exitProcess(1)
+        }
 
-        println(
+        val handler = ArchiveCopyHandler(versionType, versionNumber)
+        val client = client?.let { handler.tryCreate(it, "client") }
+        val server = server?.let { handler.tryCreate(it, "server") }
+        if (handler.isFailing()) {
+            handler.printExceptions()
+            System.err.println()
+            if (stacktrace) {
+                throw handler.takeExceptions()!!
+            } else {
+                System.err.println("Add --stacktrace to view stacktrace")
+            }
+            exitProcess(1)
+        }
+
+        print(
             """
             {
-                "id": "${parseId(fileName)}",
-                "type": "$type",
-                "releaseTime": $releaseTime,
-                "url": "${url + fileName.replace(" ", "%20")}",
-                "sha256": "${HashUtils.sha256(path)}",
-                "size": ${Files.size(path)}
+                "id": "$versionNumber",
+                "type": "$versionType",
+                "releaseTime": $releaseTime
+        """.trimIndent()
+        )
+        client?.let { printArchiveEntry(it, "client") }
+        server?.let { printArchiveEntry(it, "server") }
+        println(
+            """
+            
             }
         """.trimIndent()
         )
     }
 
-    private fun parseId(fileName: String): String {
-        return fileName.split("-")[1].split(".jar")[0]
+    private fun printArchiveEntry(path: Path, side: String) {
+        print(
+            """
+            ,
+                "$side": {
+                    "url": "${URI(baseUrl + path.joinToString("/")).toURL()}",
+                    "sha256": "${HashUtils.sha256(path)}",
+                    "size": ${path.fileSize()}
+                }
+        """.trimIndent())
     }
 }

--- a/src/main/kotlin/dev/crmodders/versionsgen/utils/ArchiveCopyHandler.kt
+++ b/src/main/kotlin/dev/crmodders/versionsgen/utils/ArchiveCopyHandler.kt
@@ -1,0 +1,81 @@
+package dev.crmodders.versionsgen.utils
+
+import java.net.URI
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+import kotlin.io.path.*
+
+class ArchiveCopyHandler(private val versionType: String, private val versionNumber: String) {
+    private val exceptions = mutableListOf<Pair<String, Exception>>()
+
+    private fun create(s: String, side: String): Path {
+        // Prefer directly operating on files if possible
+        val path = try {
+            URI(s).toPath()
+        } catch (_: Exception) {
+            try {
+                Path(s)
+            } catch (_: Exception) {
+                null
+            }
+        }?.toAbsolutePath()?.normalize()
+
+        // Operate directly on files since it's smarter at skipping self-copying
+        // Don't fall back to URLs when path is absolute
+        return if (path != null && (path.exists() || path.isAbsolute.also {
+            if (!path.exists()) {
+                throw java.nio.file.NoSuchFileException(s, path.toString(), null)
+            }
+        })) {
+            if (!path.isRegularFile()) {
+                throw java.nio.file.NoSuchFileException(s, path.toString(), "not a file")
+            }
+
+            val dest = Path("versions", versionType, versionNumber, side)
+                .createDirectories()
+                .resolve(path.fileName)
+            path.copyTo(dest, StandardCopyOption.COPY_ATTRIBUTES, StandardCopyOption.REPLACE_EXISTING)
+            dest
+        } else {
+            val uri = URI(s)
+            val url = if (uri.isAbsolute) {
+                uri
+            } else {
+                URI("https", s, null)
+            }.normalize().toURL()
+
+            val fileName = url.path.substringAfterLast('/')
+            val dest = Path("versions", versionType, versionNumber, side, fileName)
+
+            dest.createParentDirectories().outputStream().buffered().use { out ->
+                url.openStream().buffered().use { it.transferTo(out) }
+            }
+            dest
+        }
+    }
+
+    fun tryCreate(s: String, side: String): Path? {
+        return try {
+            this.create(s, side)
+        } catch (cause: Exception) {
+            this.exceptions.add(side to cause)
+            null
+        }
+    }
+
+    fun isFailing(): Boolean = exceptions.isNotEmpty()
+
+    fun printExceptions() = exceptions.forEach { (side, cause) ->
+        System.err.println("Unable create $side archive: $cause")
+    }
+
+    fun takeExceptions(): Exception? {
+        val iterator = exceptions.iterator()
+        if (!iterator.hasNext()) {
+            return null
+        }
+        val (_, cause) = iterator.next()
+        iterator.forEach { (_, other) -> cause.addSuppressed(other) }
+        return cause
+    }
+}


### PR DESCRIPTION
## Subcommand `file`
* Add limited autocomplete support to some arguments
* Added a long description with helpful details to consider while using
* Automatically copies archives to correct location
* Prints help on empty arguments
* Renamed and add alternate names to some arguments
* Stacktrace option to show verbose errors
* Support separate client and server archive, also reflected in JSON
* Support URLs for client and server archive location

### Additional Notes
* Require version number (manual)